### PR TITLE
fix for issue 2, swap failure

### DIFF
--- a/rsrsyncLive.sh
+++ b/rsrsyncLive.sh
@@ -41,12 +41,13 @@ function CREATE_SWAP() {
   cat > /tmp/swap.sh <<EOF
 #!/usr/bin/env bash
 if [ ! "\$(swapon -s | grep -v Filename)" ];then
-  SWAPFILE="/tmp/SwapFile"
+  SWAPFILE="/SwapFile"
   if [ -f "\${SWAPFILE}" ];then
     swapoff -a
     rm \${SWAPFILE}
   fi
-  dd if=/dev/zero of=\${SWAPFILE} bs=1M count=2048
+  dd if=/dev/zero of=\${SWAPFILE} bs=1M count=1024
+  chmod 600 \${SWAPFILE}
   mkswap \${SWAPFILE}
   swapon \${SWAPFILE}
 fi


### PR DESCRIPTION
- On Fedora 19/20 the os requires that the swap file have a permission
  setting of at least 600. The script was using the default umask
  which was setting the permissions to 644. The swap function now sets
  the permissions of the swap file to 600.
- In addition to the permission issue i discovered that in Fedora
  19/20 the swap file can not exist in "/tmp", to correct this I moved
  the swap file to "/".
- Lastly, because i was making changes to the script I decied to
  reduced the swap file size from 2048 to 1024. I made this last change
  because 2048 is excessive for a swap file that may never even be used.
