### PR TITLE
Fix for issue 6

### DIFF
--- a/rsrsyncLive.sh
+++ b/rsrsyncLive.sh
@@ -486,7 +486,7 @@ correct the OS detection issues
 function DISTROCHECK() {
   # Check the Source Distro
   if [ -f /etc/issue ];then
-    if [ "$(grep -i '\(centos\)\|\(red\)|\(scientific\)' /etc/issue)"  ]; then
+    if [ "$(grep -i '\(centos\)\|\(red\)\|\(scientific\)' /etc/issue)"  ]; then
       WHENRHEL
     elif [ "$(grep -i '\(fedora\)\|\(amazon\)' /etc/issue)"  ]; then
       WHENRHEL


### PR DESCRIPTION
This is an issue where the redhat systems are not detected.

The issues was a missing escape '\' which made anything other
than centos impossible to detect.

Issue:
https://github.com/cloudnull/InstanceSync/issues/6
